### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ on:
       - main
       - next
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/enjoy06/slug/security/code-scanning/2](https://github.com/enjoy06/slug/security/code-scanning/2)

To fix the issue, we will add a `permissions` block to the root of the workflow file. This block will apply to all jobs in the workflow unless overridden by job-specific `permissions` blocks. Since the workflow only performs linting and type-checking, it likely only requires read access to the repository contents. We will set `contents: read` as the minimal required permission.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
